### PR TITLE
Use GHC 9.8.1

### DIFF
--- a/.github/workflows/an.yaml
+++ b/.github/workflows/an.yaml
@@ -10,10 +10,10 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - uses: haskell/actions/setup@v2
+    - uses: haskell-actions/setup@v2
       id: setup
       with:
-        ghc-version: 9.2.4
+        ghc-version: 9.8.1
 
     - uses: actions/cache@v3
       with:

--- a/.github/workflows/event.yaml
+++ b/.github/workflows/event.yaml
@@ -10,9 +10,9 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - uses: haskell/actions/setup@v2
+    - uses: haskell-actions/setup@v2
       with:
-        ghc-version: 9.2.4
+        ghc-version: 9.8.1
 
     - uses: actions/cache@v3
       with:

--- a/.github/workflows/managed-async.yaml
+++ b/.github/workflows/managed-async.yaml
@@ -10,10 +10,10 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - uses: haskell/actions/setup@v2
+    - uses: haskell-actions/setup@v2
       id: setup
       with:
-        ghc-version: 9.2.4
+        ghc-version: 9.8.1
 
     - uses: actions/cache@v3
       with:

--- a/.github/workflows/named.yaml
+++ b/.github/workflows/named.yaml
@@ -10,10 +10,10 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - uses: haskell/actions/setup@v2
+    - uses: haskell-actions/setup@v2
       id: setup
       with:
-        ghc-version: 9.2.4
+        ghc-version: 9.8.1
 
     - uses: actions/cache@v3
       with:

--- a/.github/workflows/variant.yaml
+++ b/.github/workflows/variant.yaml
@@ -10,10 +10,10 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - uses: haskell/actions/setup@v2
+    - uses: haskell-actions/setup@v2
       id: setup
       with:
-        ghc-version: 9.2.4
+        ghc-version: 9.8.1
 
     - uses: actions/cache@v3
       with:

--- a/an/tests/Main.hs
+++ b/an/tests/Main.hs
@@ -10,7 +10,7 @@ import Type.Reflection (Typeable)
 
 main :: IO ()
 main = hspec do
-  let lift :: Either String Int -> An (Ord && Hashable && Show && Typeable)
+  let lift :: Either Int String -> An (Ord && Hashable && Show && Typeable)
       lift = either A A
 
   prop "Eq" \x y -> (lift x == lift y) == (x == y)

--- a/event/source/Data/Event.hs
+++ b/event/source/Data/Event.hs
@@ -14,7 +14,7 @@ module Data.Event
     sample,
   ) where
 
-import Control.Applicative (Alternative (..), liftA2)
+import Control.Applicative (Alternative (..))
 import Control.Monad (join)
 import Data.Foldable (for_)
 import Data.IORef (atomicModifyIORef', newIORef, readIORef, writeIORef)


### PR DESCRIPTION
Basically a no-op except that the `Typeable` ordering of `Int` and `String` seems to have changed.