### PR TITLE
Add the `via` library

### DIFF
--- a/.github/workflows/via.yaml
+++ b/.github/workflows/via.yaml
@@ -1,0 +1,36 @@
+name: via
+
+on:
+  push:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - run: sudo apt-get install -y libsdl2-dev
+
+    - uses: actions/checkout@v3
+
+    - uses: haskell-actions/setup@v2
+      id: setup
+      with:
+        ghc-version: 9.8.1
+
+    - uses: actions/cache@v3
+      with:
+        key: via-build
+        path: |
+          ${{ steps.setup.outputs.cabal-store }}
+          dist-newstyle
+          ~/.ghcup
+
+    - run: cabal update
+
+    - run: cabal build via --only-dependencies
+
+    - run: cabal build via --ghc-options=-Werror
+
+    - run: cabal build via:test:tests --ghc-options=-Werror
+
+    - run: cabal test via

--- a/via/README.md
+++ b/via/README.md
@@ -1,0 +1,36 @@
+# `Via`
+
+A type to allow deriving values via arbitrary isomorphisms.
+
+## What?
+
+I wanted to use `DerivingVia` to derive something via a `From` instance (from
+the `witch` package). I assumed a type would exist for this, so I googled and
+found [a Tweag project][iso-deriving]. However, it only allows you to derive
+via one kind of isomorphism that has to be fixed at the declaration site. This
+package is the same thing but more general.
+
+## How?
+
+Isomorphisms (or, in some cases, one way projections/injections) are defined
+according to some constraint. For example, the isomorphism when two types are
+constrained by `(~)` is `id`. When constrained by `Coercible`, it's `coerce`.
+The `In` and `Out` classes allow you to define how a mapping between types
+should be defined for any given class.
+
+Then, `(x + c)` is a type constructor that we can use to derive via `x` using
+the `c` constraint. For example:
+
+```haskell
+type Url :: Type
+data Url = Url { .. }
+  deriving stock (Eq, Generic, Ord)
+  deriving Show via (String + From) Url
+```
+
+Here, we want to derive a `Show` instance via the `String` type, but our `Url`
+type is not representationally equal to `String`. However, we declare that a
+`From Url String` instance exists, and this type allows us to derive the
+instance _via_ that relationship.
+
+[iso-deriving]: https://www.tweag.io/blog/2020-04-23-deriving-isomorphically/

--- a/via/source/Data/Via.hs
+++ b/via/source/Data/Via.hs
@@ -1,0 +1,68 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE UndecidableSuperClasses #-}
+
+-- |
+-- Derivation by conversion to other types.
+module Data.Via where
+
+import Data.Coerce (Coercible, coerce)
+import Data.Function (on)
+import Data.Kind (Constraint)
+import Data.Kind (Type)
+import Witch (From (from))
+
+-- | A newtype wrapper around the @y@ type. We use this to say, "I can map @x@
+-- to @y@ and/or the reverse if @c@ is available".
+type (+) :: Type -> (Type -> Type -> Constraint) -> Type -> Type
+newtype (x + c) y = With { getWith :: y }
+
+instance (Eq x, Out c x y) => Eq ((x + c) y) where
+  (==) = (==) @x `on` (outbound @c . getWith)
+
+instance (Ord x, Out c x y) => Ord ((x + c) y) where
+  compare = compare @x `on` (outbound @c . getWith)
+
+instance (Show x, Out c x y) => Show ((x + c) y) where
+  show = show @x . outbound @c . getWith
+
+instance (Semigroup x, Exchange c x y) => Semigroup ((x + c) y) where
+  this <> that = With (inbound @c (go this that))
+    where go = (<>) @x `on` (outbound @c . getWith)
+
+instance (Monoid x, Exchange c x y) => Monoid ((x + c) y) where
+  mempty = With (inbound @c @x mempty)
+
+-- | A synonym for a constraint that requires both directions of conversion.
+type Exchange :: (Type -> Type -> Constraint) -> Type -> Type -> Constraint
+type Exchange c x y = (In c x y, Out c x y)
+
+-- | A generalisation of the @iso-deriving@ @Inject@ class to allow users to
+-- decsribe the specific injection being used.
+type In :: (Type -> Type -> Constraint) -> Type -> Type -> Constraint
+class c x y => In c x y where
+  inbound :: x -> y
+
+instance x ~ y => In (~) x y where
+  inbound = id
+
+instance Coercible x y => In Coercible x y where
+  inbound = coerce
+
+instance From x y => In From x y where
+  inbound = from
+
+-- | A generalisation of the @iso-deriving@ @Project@ class to allow users to
+-- describe the specific projection being used.
+type Out :: (Type -> Type -> Constraint) -> Type -> Type -> Constraint
+class c y x => Out c x y where
+  outbound :: y -> x
+
+instance x ~ y => Out (~) x y where
+  outbound = id
+
+instance Coercible x y => Out Coercible x y where
+  outbound = coerce
+
+instance From y x => Out From x y where
+  outbound = from

--- a/via/tests/Main.hs
+++ b/via/tests/Main.hs
@@ -1,0 +1,47 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE ViewPatterns #-}
+
+module Main where
+
+import Data.Coerce (Coercible)
+import Data.Kind (Type)
+import Data.Monoid (Sum (Sum))
+import Data.Via
+import GHC.Generics (Generic)
+import Witch (From (..))
+import Test.Hspec (describe, hspec)
+import Test.Hspec.QuickCheck (prop)
+
+type Fahrenheit :: Type
+newtype Fahrenheit = Fahrenheit Double
+  deriving stock (Generic, Show)
+  deriving (Semigroup, Monoid) via (Sum Double + Coercible) Fahrenheit
+  deriving (Eq, Ord) via (Celsius + From) Fahrenheit
+
+instance From Fahrenheit Celsius where
+  from (Fahrenheit x) = Celsius ((x - 32) / 1.8)
+
+type Celsius :: Type
+newtype Celsius = Celsius Double
+  deriving stock (Eq, Generic, Ord, Show)
+  deriving (Semigroup, Monoid) via (Fahrenheit + Coercible) Celsius
+
+instance From Celsius Fahrenheit where
+  from (Celsius x) = Fahrenheit (x * 1.8 + 32)
+
+main :: IO ()
+main = hspec do
+  describe "Coercible" do
+    prop "Semigroup Fahrenheit" \x y ->
+      Fahrenheit x <> Fahrenheit y == Fahrenheit (x + y)
+
+    prop "Semigroup Celsius" \x y ->
+      Celsius x <> Celsius y == Celsius (x + y)
+
+  describe "From" do
+    prop "Eq Fahrenheit" \(Fahrenheit -> x) (Fahrenheit -> y) ->
+      (x == y) == (from @_ @Celsius x == from @_ @Celsius y)
+
+    prop "Ord Fahrenheit" \(Fahrenheit -> x) (Fahrenheit -> y) ->
+      compare x y == compare (from @_ @Celsius x) (from @_ @Celsius y)

--- a/via/via.cabal
+++ b/via/via.cabal
@@ -1,0 +1,23 @@
+cabal-version: 3.0
+name: via
+version: 0.0.0.0
+
+library
+  exposed-modules:
+    Data.Via
+  build-depends:
+    , base
+    , witch
+  hs-source-dirs: source
+  default-language: GHC2021
+
+test-suite tests
+  build-depends:
+    , via
+    , base
+    , hspec
+    , witch
+  main-is: Main.hs
+  type: exitcode-stdio-1.0
+  hs-source-dirs: tests
+  default-language: GHC2021


### PR DESCRIPTION
This type allows us to derive types via any isomorphism, rather than just `Coercible` isomorphisms.