### PR TITLE
Use the PR trigger instead of the push trigger

### DIFF
--- a/.github/workflows/an.yaml
+++ b/.github/workflows/an.yaml
@@ -1,7 +1,7 @@
 name: an
 
 on:
-  push:
+  pull_request:
 
 jobs:
   test:

--- a/.github/workflows/application.yaml
+++ b/.github/workflows/application.yaml
@@ -1,7 +1,7 @@
 name: application
 
 on:
-  push:
+  pull_request:
 
 jobs:
   test:

--- a/.github/workflows/approx.cabal
+++ b/.github/workflows/approx.cabal
@@ -1,7 +1,7 @@
 name: approx
 
 on:
-  push:
+  pull_request:
 
 jobs:
   test:

--- a/.github/workflows/autobiographer.yaml
+++ b/.github/workflows/autobiographer.yaml
@@ -1,7 +1,7 @@
 name: autobiographer
 
 on:
-  push:
+  pull_request:
 
 jobs:
   test:

--- a/.github/workflows/event.yaml
+++ b/.github/workflows/event.yaml
@@ -1,7 +1,7 @@
 name: event
 
 on:
-  push:
+  pull_request:
 
 jobs:
   test:

--- a/.github/workflows/herald.yaml
+++ b/.github/workflows/herald.yaml
@@ -1,7 +1,7 @@
 name: herald
 
 on:
-  push:
+  pull_request:
 
 jobs:
   test:

--- a/.github/workflows/incremental.yaml
+++ b/.github/workflows/incremental.yaml
@@ -1,7 +1,7 @@
 name: incremental
 
 on:
-  push:
+  pull_request:
 
 jobs:
   test:

--- a/.github/workflows/managed-async.yaml
+++ b/.github/workflows/managed-async.yaml
@@ -1,7 +1,7 @@
 name: managed-async
 
 on:
-  push:
+  pull_request:
 
 jobs:
   test:

--- a/.github/workflows/named.yaml
+++ b/.github/workflows/named.yaml
@@ -1,7 +1,7 @@
 name: named
 
 on:
-  push:
+  pull_request:
 
 jobs:
   test:

--- a/.github/workflows/paparazzi.yaml
+++ b/.github/workflows/paparazzi.yaml
@@ -1,7 +1,7 @@
 name: paparazzi
 
 on:
-  push:
+  pull_request:
 
 jobs:
   test:

--- a/.github/workflows/postfix.yaml
+++ b/.github/workflows/postfix.yaml
@@ -1,7 +1,7 @@
 name: postfix
 
 on:
-  push:
+  pull_request:
 
 jobs:
   test:

--- a/.github/workflows/units.yaml
+++ b/.github/workflows/units.yaml
@@ -1,7 +1,7 @@
 name: units
 
 on:
-  push:
+  pull_request:
 
 jobs:
   test:

--- a/.github/workflows/variant.yaml
+++ b/.github/workflows/variant.yaml
@@ -1,7 +1,7 @@
 name: variant
 
 on:
-  push:
+  pull_request:
 
 jobs:
   test:

--- a/.github/workflows/via.yaml
+++ b/.github/workflows/via.yaml
@@ -1,7 +1,7 @@
 name: via
 
 on:
-  push:
+  pull_request:
 
 jobs:
   test:


### PR DESCRIPTION
We don't need these jobs to run until a PR exists, so this should mean we run fewer CI jobs.