### PR TITLE
Generic profunctors

### DIFF
--- a/generic-profunctors/README.md
+++ b/generic-profunctors/README.md
@@ -1,0 +1,3 @@
+# 🩻 Generic Profunctors
+
+Now we have `constrained-categories` to define a category hierarchy with constrained elements, and we've built `enriched-profunctors` on top of that hierarchy to provide profunctors over categories other than `Hask`, I want to be able to talk about generic representations in this more generalised language. If we specialise the arrows here to function arrows, everything collapses to the generics we know and love. However, we can now make transformations over more interesting structures as well.

--- a/generic-profunctors/generic-profunctors.cabal
+++ b/generic-profunctors/generic-profunctors.cabal
@@ -1,0 +1,37 @@
+cabal-version: 3.0
+name: generic-profunctors
+version: 0.0.0.0
+
+library
+  exposed-modules:
+    Control.Category.Generic
+    Data.Profunctor.Generic
+    Data.Optics.Constructor
+    Data.Optics.Field
+    Data.Optics.Helper
+  build-depends:
+    , base
+    , constrained
+    , constrained-categories
+    , enriched-profunctors
+  hs-source-dirs: source
+  default-language: GHC2021
+
+test-suite tests
+  build-depends:
+    , base
+    , generic-profunctors
+    , hspec
+    , profunctors
+    , QuickCheck
+    , tasty
+    , tasty-hspec
+  build-tool-depends:
+    tasty-discover:tasty-discover
+  main-is: Driver.hs
+  other-modules:
+    Test.ConstructorSpec
+    Test.FieldSpec
+  type: exitcode-stdio-1.0
+  hs-source-dirs: tests
+  default-language: GHC2021

--- a/generic-profunctors/source/Control/Category/Generic.hs
+++ b/generic-profunctors/source/Control/Category/Generic.hs
@@ -1,0 +1,39 @@
+{-# LANGUAGE ExplicitNamespaces #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE MonoLocalBinds #-}
+{-# LANGUAGE QuantifiedConstraints #-}
+
+-- | Categories for interacting with generic representations.
+module Control.Category.Generic where
+
+import Control.Cartesian.Constrained (Cartesian (..))
+import Control.Category.Constrained (Category (..), type (~>) (..))
+import Control.Cocartesian.Constrained (Cocartesian (..))
+import Data.Constraint.Proof (Preserves)
+import Data.Kind (Constraint, Type)
+import GHC.Generics (M1 (..), (:*:), (:+:))
+
+-- | A type synonym to make the signatures bearable.
+type RepK :: Type
+type RepK = Type -> Type
+
+-- | A class for categories that are able to represent generic representations.
+type GenericC :: ((Type -> Type) -> Constraint) -> ((Type -> Type) -> (Type -> Type) -> Type) -> Constraint
+class
+  (Cartesian c (:*:) k, Cocartesian c (:+:) k, forall i m. Preserves (M1 i m) c) =>
+  GenericC c k
+    | k -> c
+  where
+  -- | Wrap a value in metadata.
+  _M1 :: (c x) => k x (M1 i m x)
+
+  -- | Unwrap a value inside metadata.
+  _unM1 :: (c x) => k (M1 i m x) x
+
+instance GenericC Functor (~>) where
+  _M1 = NT M1
+  _unM1 = NT unM1
+
+-- | A neater type synonym for "GenericC".
+type GenericC' :: (RepK -> RepK -> Type) -> Constraint
+type GenericC' k = GenericC (Obj k) k

--- a/generic-profunctors/source/Data/Optics/Constructor.hs
+++ b/generic-profunctors/source/Data/Optics/Constructor.hs
@@ -1,0 +1,60 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE MonoLocalBinds #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+-- | Generic optics for constructors.
+module Data.Optics.Constructor where
+
+import Control.Category.Generic (RepK)
+import Data.Kind (Constraint, Type)
+import Data.Optics.Helper (ConstructorPath, Step)
+import Data.Profunctor.Choice.Enriched (left', right')
+import Data.Profunctor.Enriched (Obj)
+import Data.Profunctor.Generic (Generically (..), Generically', HasGenerics', meta)
+import GHC.Generics hiding (Generically)
+import GHC.TypeLits (Symbol)
+
+-- | Generic machinery for "HasConstructor".
+type GHasConstructor :: [Step] -> (RepK -> RepK -> Type) -> RepK -> Type -> Constraint
+class (HasGenerics' p) => GHasConstructor path p rep a | path rep -> a where
+  gconstructor :: p (K1 R a) (K1 R a) -> p rep rep
+
+-- | Convenience synonym for "GHasConstructor".
+type GHasConstructor' :: (RepK -> RepK -> Type) -> Symbol -> Type -> Type -> Constraint
+type GHasConstructor' p x s a = GHasConstructor (ConstructorPath x s) p (Rep s) a
+
+instance
+  (GHasConstructor path p s a, Obj p s) =>
+  GHasConstructor path p (M1 i m s) a
+  where
+  gconstructor = meta . gconstructor @path
+
+instance
+  (GHasConstructor path p l a, Obj p l, Obj p r) =>
+  GHasConstructor ('Left ': path) p (l :+: r) a
+  where
+  gconstructor = left' . gconstructor @path
+
+instance
+  (GHasConstructor path p r a, Obj p l, Obj p r) =>
+  GHasConstructor ('Right ': path) p (l :+: r) a
+  where
+  gconstructor = right' . gconstructor @path
+
+instance (HasGenerics' p, s ~ a) => GHasConstructor '[] p (K1 R s) a where
+  gconstructor = id
+
+-- | A class for lifting profunctors over entire types.
+type HasConstructor :: Symbol -> (Type -> Type -> Type) -> Type -> Type -> Constraint
+class HasConstructor x p s a | x s -> a where
+  -- | Lift an arrow over a field into an arrow over its ADT.
+  constructor :: p a a -> p s s
+
+instance
+  (Generic s, Generically' p, GHasConstructor' (Representation p) x s a) =>
+  HasConstructor x p s a
+  where
+  constructor = generically . gconstructor @(ConstructorPath x s) . ungenerically

--- a/generic-profunctors/source/Data/Optics/Field.hs
+++ b/generic-profunctors/source/Data/Optics/Field.hs
@@ -1,0 +1,57 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE MonoLocalBinds #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+-- | Generic optics for fields.
+module Data.Optics.Field where
+
+import Control.Category.Generic (RepK)
+import Data.Kind (Constraint, Type)
+import Data.Optics.Helper (FieldPath, Step)
+import Data.Profunctor.Enriched (Obj)
+import Data.Profunctor.Generic (Generically (..), Generically', HasGenerics', meta)
+import Data.Profunctor.Strong.Enriched (first', second')
+import GHC.Generics hiding (Generically)
+import GHC.TypeLits (Symbol)
+
+-- | Generic machinery for "HasField".
+type GHasField :: [Step] -> (RepK -> RepK -> Type) -> RepK -> Type -> Constraint
+class (HasGenerics' p) => GHasField path p rep a | path rep -> a where
+  gfield :: p (K1 R a) (K1 R a) -> p rep rep
+
+-- | Convenience synonym for "GHasField".
+type GHasField' :: (RepK -> RepK -> Type) -> Symbol -> Type -> Type -> Constraint
+type GHasField' p x s a = GHasField (FieldPath x s) p (Rep s) a
+
+instance (GHasField path p s a, Obj p s) => GHasField path p (M1 i m s) a where
+  gfield = meta . gfield @path
+
+instance
+  (GHasField path p l a, Obj p l, Obj p r) =>
+  GHasField ('Left ': path) p (l :*: r) a
+  where
+  gfield = first' . gfield @path
+
+instance
+  (GHasField path p r a, Obj p l, Obj p r) =>
+  GHasField ('Right ': path) p (l :*: r) a
+  where
+  gfield = second' . gfield @path
+
+instance (HasGenerics' p, s ~ a) => GHasField '[] p (K1 R s) a where
+  gfield = id
+
+-- | A class for lifting profunctors over entire types.
+type HasField :: Symbol -> (Type -> Type -> Type) -> Type -> Type -> Constraint
+class HasField x p s a | x s -> a where
+  -- | Lift an arrow over a field into an arrow over its ADT.
+  field :: p a a -> p s s
+
+instance
+  (Generic s, Generically' p, GHasField' (Representation p) x s a) =>
+  HasField x p s a
+  where
+  field = generically . gfield @(FieldPath x s) . ungenerically

--- a/generic-profunctors/source/Data/Optics/Helper.hs
+++ b/generic-profunctors/source/Data/Optics/Helper.hs
@@ -1,0 +1,53 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+-- | Helpers for creating generic optics.
+module Data.Optics.Helper where
+
+import Data.Kind (Type)
+import GHC.Generics
+import GHC.TypeLits (ErrorMessage (..), Symbol, TypeError)
+
+-- | It's 'Left' or 'Right'. Unnecessarily cute.
+type Step :: Type
+type Step = () -> Either () ()
+
+-- | Calculate the path to the given element through a generic representation.
+type Path :: Type -> Symbol -> (Type -> Type) -> Type -> Maybe [Step]
+type family Path i x rep s where
+  Path S x (S1 ('MetaSel ('Just x) _ _ _) _) s = 'Just '[]
+  Path C x (C1 ('MetaCons x _ _) _) s = 'Just '[]
+  Path i x (D1 ________________________ rep) s = Path i x rep s
+  Path S x (C1 ________________________ rep) s = Path S x rep s
+  Path C x (l :+: r) s = Prepend 'Left (Path C x l s) <|> Prepend 'Right (Path C x r s)
+  Path S x (l :*: r) s = Prepend 'Left (Path S x l s) <|> Prepend 'Right (Path S x r s)
+
+type Prepend :: Step -> Maybe [Step] -> Maybe [Step]
+type family Prepend x xs where
+  Prepend x ('Just xs) = 'Just (x ': xs)
+  Prepend x 'Nothing = 'Nothing
+
+-- | Choose the first non-@Nothing@ value.
+type (<|>) :: Maybe [Step] -> Maybe [Step] -> Maybe [Step]
+type family xs <|> ys where
+  'Just xs <|> _ = 'Just xs
+  'Nothing <|> y = y
+
+-- | If the value is @Nothing@, raise an error.
+type OnNothing :: Maybe [Step] -> ErrorMessage -> [Step]
+type family OnNothing x e where
+  OnNothing 'Nothing e = TypeError e
+  OnNothing ('Just xs) _ = xs
+
+-- | An error for missing fields.
+type FieldPath :: Symbol -> Type -> [Step]
+type FieldPath x s =
+  Path S x (Rep s) s
+    `OnNothing` ('Text x ':<>: 'Text " ∉ " ':<>: 'ShowType s)
+
+-- | An error for missing constructors.
+type ConstructorPath :: Symbol -> Type -> [Step]
+type ConstructorPath x s =
+  Path C x (Rep s) s
+    `OnNothing` ('Text x ':<>: 'Text " ∉ " ':<>: 'ShowType s)

--- a/generic-profunctors/source/Data/Profunctor/Generic.hs
+++ b/generic-profunctors/source/Data/Profunctor/Generic.hs
@@ -1,0 +1,63 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE ImpredicativeTypes #-}
+{-# LANGUAGE QuantifiedConstraints #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+-- | Profunctors specifically for handling generic representations.
+module Data.Profunctor.Generic where
+
+import Control.Category.Constrained (Category ((.)), type (~>) (..))
+import Control.Category.Generic (GenericC (..), GenericC', RepK)
+import Data.Constraint.Proof (Maps)
+import Data.Kind (Constraint, Type)
+import Data.Profunctor.Choice.Enriched (Choice)
+import Data.Profunctor.Enriched (Obj, Profunctor (..))
+import Data.Profunctor.Strong.Enriched (Strong)
+import GHC.Generics hiding (Generically)
+import Prelude hiding ((.))
+
+-- | Profunctors that we can use to handle generic representations.
+type HasGenerics :: (RepK -> RepK -> Type) -> (RepK -> RepK -> Type) -> Constraint
+class (Strong k p, Choice k p, GenericC' k) => HasGenerics k p | p -> k
+
+instance (Strong k p, Choice k p, GenericC' k) => HasGenerics k p
+
+-- | A neater type synonym for "HasGenerics".
+type HasGenerics' :: (RepK -> RepK -> Type) -> Constraint
+type HasGenerics' p = HasGenerics (Cat p) p
+
+-- | A metadata profunctor transformation.
+meta :: (HasGenerics' p, Obj p x, Obj p y) => p x y -> p (M1 i m x) (M1 i m y)
+meta = dimap _unM1 _M1
+
+-- | A class that links two profunctors together: one that supports arrows over
+-- @Type@ data, and one that supports arrows over their generic representations.
+type Generically :: (Type -> Type -> Type) -> (RepK -> RepK -> Type) -> Constraint
+class
+  (HasGenerics' p', Representation p ~ p', Maps (K1 R) (Obj p) (Obj p')) =>
+  Generically p p'
+    | p -> p'
+  where
+  -- | The profunctor for generic representations of @p@ objects. This should
+  -- always be @p'@. Usually, we can use "Generically'" to make the signatures
+  -- nicer, but having the type instance variable allows for quantified
+  -- constraints.
+  type Representation p :: RepK -> RepK -> Type
+
+  -- | Create an arrow between types from an arrow between representations.
+  generically :: (Generic x, Generic y) => p' (Rep x) (Rep y) -> p x y
+
+  -- | Create an arrow between representations from an arrow between types.
+  ungenerically :: p x y -> p' (K1 R x) (K1 R y)
+
+-- | A type synonym to hide the second type variable.
+type Generically' :: (Type -> Type -> Type) -> Constraint
+type Generically' p = Generically p (Representation p)
+
+instance Generically (->) (~>) where
+  type Representation (->) = (~>)
+
+  generically (NT f) = to . f . from
+  ungenerically f = NT \(K1 x) -> K1 (f x)

--- a/generic-profunctors/tests/Driver.hs
+++ b/generic-profunctors/tests/Driver.hs
@@ -1,0 +1,1 @@
+{-# OPTIONS_GHC -F -pgmF tasty-discover #-}

--- a/generic-profunctors/tests/Test/ConstructorSpec.hs
+++ b/generic-profunctors/tests/Test/ConstructorSpec.hs
@@ -1,0 +1,28 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE DataKinds #-}
+
+module Test.ConstructorSpec where
+
+import Data.Kind (Type)
+import Data.Optics.Constructor (constructor)
+import Data.Profunctor (Forget (..))
+import GHC.Generics (Generic)
+import Test.Hspec (Spec, describe, it)
+
+type Choice :: Type
+data Choice = This Int | That Bool
+  deriving (Eq, Generic, Ord, Show)
+
+setThis :: Int -> Choice -> Choice
+setThis x = constructor @"This" \_ -> x
+
+getThis :: Choice -> Maybe Int
+getThis = runForget (constructor @"This" (Forget Just))
+
+spec_constructor :: Spec
+spec_constructor = describe "Constructor" do
+  it "can set the This constructor" do
+    setThis 10 (This 5) == This 10
+
+  it "can get the This constructor" do
+    getThis (This 5) == Just 5

--- a/generic-profunctors/tests/Test/FieldSpec.hs
+++ b/generic-profunctors/tests/Test/FieldSpec.hs
@@ -1,0 +1,28 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE DataKinds #-}
+
+module Test.FieldSpec where
+
+import Data.Kind (Type)
+import Data.Optics.Field (field)
+import Data.Profunctor (Forget (..))
+import GHC.Generics (Generic)
+import Test.Hspec (Spec, describe, it)
+
+type User :: Type
+data User = User {name :: String, age :: Int, likesDogs :: Bool}
+  deriving (Eq, Generic, Ord, Show)
+
+setName :: String -> User -> User
+setName x = field @"name" \_ -> x
+
+getName :: User -> String
+getName = runForget (field @"name" (Forget id))
+
+spec_fields :: Spec
+spec_fields = describe "Fields" do
+  it "can set the name field" do
+    setName "Not Tom" (User "Tom" 32 True) == User "Not Tom" 30 True
+
+  it "can get the name field" do
+    getName (User "Tom" 30 True) == "Tom"


### PR DESCRIPTION
Probably not the best name for this library. In short, with the `enriched-profunctor` vocabulary, we can generalise the category of arrows over generic representations. This allows us to reinterpret full generic programs.